### PR TITLE
Languages are case insensitive

### DIFF
--- a/src/com/maxprograms/tmxvalidation/TMXValidatingHandler.java
+++ b/src/com/maxprograms/tmxvalidation/TMXValidatingHandler.java
@@ -299,7 +299,7 @@ public class TMXValidatingHandler implements IContentHandler {
 			if (lang.isEmpty()) {
 				throw new SAXException(Messages.getString("TMXValidatingHandler.17"));
 			}
-			if (lang.equals(srcLang)) {
+			if (lang.equalsIgnoreCase(srcLang)) {
 				found = true;
 			}
 		}


### PR DESCRIPTION
Recently I had a TMX to validate and received the following message:
ERROR: <tu> element lacks <tuv> with language set to 'EN'

Having a look in the file I saw that it declares
&lt;header [...] adminlang='EN' />
and in the contents of one <tu> I saw
&lt;tuv xml:lang="en">

Changing the srclang to "en" solved the problem, meaning that the problem was really the case of the text in attributes.

That sounds strange to me because as far as I know, BCP47 tags are case-insensitive so that should be acceptable.
Before considering it as a bug I first had a look to the TMX 1.4 specification and found this:
srclang
    Source language - Specifies the language of the source text. In other words, the [<tuv>](https://www.ttt.org/oscarStandards/tmx/#tuv) holding the source segment will have its [xml:lang](https://www.ttt.org/oscarStandards/tmx/#xml:lang) attribute set to the same value as srclang. (except if srclang is set to "*all*"). If a [<tu>](https://www.ttt.org/oscarStandards/tmx/#tu) element does not have a srclang attribute specified, it uses the one defined in the [<header>](https://www.ttt.org/oscarStandards/tmx/#header) element.
    Value description:
        A language code as described in the [[RFC 3066](https://www.ttt.org/oscarStandards/tmx/#refRFC3066)], or the value "*all*" if any language can be used as the source language. **Unlike the other TMX attributes, the values for srclang are not case-sensitive.**

So, my impression is that TMX specification says that adminlang and xml:lang should be considered as case insensitive. I found later the same line related to xml:lang attribute, meaning that srclang="en" and xml:lang="EN" should be considered as identical.
